### PR TITLE
Add option to choose RGB or HSV for interpolation

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,12 +151,12 @@ contains(values: Node[], value: Node) => Node
 
 Interpolate the node from 0 to 1 without clamping.
 
-### `interpolateColors(node, inputRange, colors)`
+### `interpolateColors(node, inputRange, colors, [colorSpace = "hsv"])`
 
 Interpolate colors based on an animation value and its value range.
 
 ```js
-interpolateColors(value: Node, inputRange: number[], colors: Colors)
+interpolateColors(value: Node, inputRange: number[], colors: Colors, colorSpace?: "hsv" | "rgb")
 ```
 
 Example Usage:
@@ -172,8 +172,16 @@ const to = {
   g: 176,
   b: 68,
 };
+
+// Interpolate in default color space (HSV)
 interpolateColors(x, [0, 1], [from, to]);
+
+// Interpolate in RGB color space
+interpolateColors(x, [0, 1], [from, to], "rgb");
 ```
+
+![](https://user-images.githubusercontent.com/616906/58366137-3d667b80-7ece-11e9-9b20-ea5e84494afc.png)
+_Interpolating between red and blue, with in-between colors shown. Image source: [this tool](https://www.alanzucconi.com/2016/01/06/colour-interpolation/4/)._
 
 ### `snapPoint(point, velocity, points)`
 

--- a/src/Colors.ts
+++ b/src/Colors.ts
@@ -98,7 +98,7 @@ const rgbToHsv = (c: RGBColor) => {
   return { h: h * 360, s, v };
 };
 
-const interpolateColors = (animationValue: Animated.Adaptable<number>, inputRange: number[], colors: RGBColor[]) => {
+const interpolateColorsHSV = (animationValue: Animated.Adaptable<number>, inputRange: number[], colors: RGBColor[]) => {
   const colorsAsHSV = colors.map(c => rgbToHsv(c));
   const h = interpolate(animationValue, {
     inputRange,
@@ -116,6 +116,41 @@ const interpolateColors = (animationValue: Animated.Adaptable<number>, inputRang
     extrapolate: Extrapolate.CLAMP,
   });
   return colorHSV(h, s, v);
+};
+
+const interpolateColorsRGB = (animationValue: Animated.Adaptable<number>, inputRange: number[], colors: RGBColor[]) => {
+  const r = round(
+    interpolate(animationValue, {
+      inputRange,
+      outputRange: colors.map(c => c.r),
+      extrapolate: Extrapolate.CLAMP,
+    }),
+  );
+  const g = round(
+    interpolate(animationValue, {
+      inputRange,
+      outputRange: colors.map(c => c.g),
+      extrapolate: Extrapolate.CLAMP,
+    }),
+  );
+  const b = round(
+    interpolate(animationValue, {
+      inputRange,
+      outputRange: colors.map(c => c.b),
+      extrapolate: Extrapolate.CLAMP,
+    }),
+  );
+  return color(r, g, b);
+};
+
+const interpolateColors = (
+  animationValue: Animated.Adaptable<number>,
+  inputRange: number[],
+  colors: RGBColor[],
+  colorSpace: "hsv" | "rgb" = "rgb",
+) => {
+  if (colorSpace === "hsv") return interpolateColorsHSV(animationValue, inputRange, colors);
+  return interpolateColorsRGB(animationValue, inputRange, colors);
 };
 
 export default interpolateColors;


### PR DESCRIPTION
It would be great to be able to choose the color space for interpolation since it yields different results depending on which color space you use. I prefer the look of interpolating in RGB (and it's cheap!) since HSV interpolation can introduce "flashes" of other colors.

You can see in the GIF that HSV interpolation shows a green color in the middle of interpolating between blue and yellow, and blue between cyan and magenta.

This also happens in RGB (blue -> yellow has a gray color in the middle), but I think it's a less jarring look.

![Kapture 2019-05-24 at 16 55 35](https://user-images.githubusercontent.com/616906/58336884-e8caee00-7e44-11e9-80c5-543edf0374b6.gif)
![Kapture 2019-05-24 at 16 56 14](https://user-images.githubusercontent.com/616906/58336885-e9638480-7e44-11e9-81f9-9815814fda1c.gif)
