### PR TITLE
fix(📚): Remove the mention of <Interactable>

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,22 +19,6 @@ atan2(y, x);
 
 ## Components
 
-### `<Interactable>`
-
-Implementation of `Interactable` from `react-native-interactable` with `react-native-gesture-handler` and `react-native-reanimated`.
-The original implementation has been built by [the reanimated team](https://github.com/kmagiera/react-native-reanimated/blob/master/Example/Interactable.js).
-Documentation of this component is available [here](https://github.com/wix/react-native-interactable).
-
-Example usage:
-
-```js
-<Interactable
-  snapPoints={[{ x: -width }, { x: 0 }, { x: width }]}
-  style={{ ...StyleSheet.absoluteFillObject, backgroundColor: "blue" }}
-  onSnap={() => alert("oh snap!")}
-/>
-```
-
 ### `<ReText>`
 
 Component that display an animation value as text.


### PR DESCRIPTION
Since we don't have the capacity to support this component at the moment. I would like to remove its mention from the documentation. I found the other functions provided by redash powerful enough to build complex gestures without `<Interactable>`.