### PR TITLE
fix(🎨): Switch default color space to rgb

### DIFF
--- a/README.md
+++ b/README.md
@@ -277,7 +277,7 @@ runDecay(clock: Clock, value: Node, velocity: Node, rerunDecaying: Node): Node
 
 Interpolate the node from 0 to 1 without clamping.
 
-### `interpolateColor(node, { inputRange, outputRange }, [colorSpace = "hsv"])`
+### `interpolateColor(node, { inputRange, outputRange }, [colorSpace = "rgb"])`
 
 Interpolate colors based on an animation value and its value range.
 
@@ -306,7 +306,7 @@ interpolateColor(x, [0, 1], [from, to]);
 interpolateColor(x, [0, 1], [from, to], "rgb");
 ```
 
-### `bInterpolateColor(node, color1, color2, [colorSpace = "hsv"])`
+### `bInterpolateColor(node, color1, color2, [colorSpace = "rgb"])`
 
 Interpolate the node from 0 to 1 without clamping.
 

--- a/src/Colors.ts
+++ b/src/Colors.ts
@@ -170,7 +170,7 @@ interface ColorInterpolationConfig {
 export const interpolateColor = (
   value: Animated.Adaptable<number>,
   config: ColorInterpolationConfig,
-  colorSpace: "hsv" | "rgb" = "hsv"
+  colorSpace: "hsv" | "rgb" = "rgb"
 ) => {
   const { inputRange, outputRange } = config;
   if (colorSpace === "hsv")
@@ -182,7 +182,7 @@ export const bInterpolateColor = (
   value: Animated.Adaptable<number>,
   color1: RGBColor,
   color2: RGBColor,
-  colorSpace: "hsv" | "rgb" = "hsv"
+  colorSpace: "hsv" | "rgb" = "rgb"
 ) =>
   interpolateColor(
     value,


### PR DESCRIPTION
BREAKING CHANGE: The default color space for interpolation is now RGB.