### PR TITLE
feat(⏰): Interruptible loop()

### DIFF
--- a/README.md
+++ b/README.md
@@ -266,7 +266,7 @@ const config = {
 runTiming(clock, 0, config);
 ```
 
-### `runLoop(duration: Node, easing: EasingFunction: boomerang? = false)`
+### `runLoop({ clock: Clock, duration: Node, easing: EasingFunction: boomerang? = false, autoStart? = true })`
 
 Returns an animated node that goes from `0` to `1` during the time set by `duration` continuously. If the `boomerang` option is set to `true`, the animation goes from `0` to `1` and then from `1` to `0` in the next cycle.
 

--- a/README.md
+++ b/README.md
@@ -266,7 +266,7 @@ const config = {
 runTiming(clock, 0, config);
 ```
 
-### `runLoop({ clock: Clock, duration: Node, easing: EasingFunction: boomerang? = false, autoStart? = true })`
+### `loop({ clock: Clock, duration: Node, easing: EasingFunction: boomerang? = false, autoStart? = true })`
 
 Returns an animated node that goes from `0` to `1` during the time set by `duration` continuously. If the `boomerang` option is set to `true`, the animation goes from `0` to `1` and then from `1` to `0` in the next cycle.
 

--- a/src/AnimationRunners.ts
+++ b/src/AnimationRunners.ts
@@ -124,12 +124,23 @@ export const runDelay = (node: Animated.Node<number>, duration: number) => {
   ]);
 };
 
-export const runLoop = (
-  clock: Animated.Clock,
-  duration: Animated.Adaptable<number>,
-  easing: Animated.EasingFunction,
-  boomerang: boolean = false
-) => {
+export interface LoopProps {
+  clock?: Animated.Clock;
+  easing?: Animated.EasingFunction;
+  duration?: number;
+  boomerang?: boolean;
+  autoStart?: boolean;
+}
+
+export const loop = (loopConfig: LoopProps) => {
+  const { clock, easing, duration, boomerang, autoStart } = {
+    clock: new Clock(),
+    easing: Easing.linear,
+    duration: 250,
+    boomerang: false,
+    autoStart: true,
+    ...loopConfig
+  };
   const state = {
     finished: new Value(0),
     position: new Value(0),
@@ -143,7 +154,7 @@ export const runLoop = (
   };
 
   return block([
-    cond(not(clockRunning(clock)), startClock(clock)),
+    cond(and(not(clockRunning(clock)), autoStart ? 1 : 0), startClock(clock)),
     timing(clock, state, config),
     cond(state.finished, [
       set(state.finished, 0),

--- a/src/AnimationRunners.ts
+++ b/src/AnimationRunners.ts
@@ -14,7 +14,8 @@ const {
   startClock,
   clockRunning,
   onChange,
-  not
+  not,
+  and
 } = Animated;
 
 export function runDecay(


### PR DESCRIPTION
@dsznajder This is how I would like the animations runner to look like in the future: 
* They should all be interruptable
* All parameters that could be optional should be optional
* Remove the `run` prefix
* We use name parameters in order to deal with the optional parameters more gracefully.

What are your thoughts on this?