### PR TITLE
feat: Allow partial SpringConfig when defining a spring animation

### DIFF
--- a/src/AnimationRunners.ts
+++ b/src/AnimationRunners.ts
@@ -149,7 +149,7 @@ export const decay = (params: DecayParams) => {
   ]);
 };
 
-export type SpringConfig = Omit<Animated.SpringConfig, "toValue">;
+export type SpringConfig = Partial<Omit<Animated.SpringConfig, "toValue">>;
 
 export interface SpringParams {
   clock?: Animated.Clock;


### PR DESCRIPTION
The user can optionally pass in a SpringConfig property to configure the stiffness, mass, and stiffness of a spring animation. Currently, they must pass in all properties if you want to change one of them, otherwise they will get an error in TypeScript. However, as the options are spread along with default values the user should be able to pass in just the properties they would like to change from the default.

This commit changes the type signature of the SpringConfig property to accept a Partial. This allows you to change from this code:

```
spring({
    from: dest,
    to: src,
    velocity,
    config: {
        damping: 6,
        mass: 1,
        stiffness: 100,
        overshootClamping: false,
        restSpeedThreshold: 0.01,
        restDisplacementThreshold: 0.01,
    }
})
```

to this code:

```
spring({
    from: dest,
    to: src,
    velocity,
    config: {
        stiffness: 100,
    }
})
```

The result would already have been the same, as it's only a TypeScript error which is the issue, but it makes the code much easier to read, especially in common situations where you want to change the damping, mass, and stiffness without changing the clamping, and thresholds.