### PR TITLE
feat: Add useSpringTransition and useSpringToggle

### DIFF
--- a/README.md
+++ b/README.md
@@ -250,6 +250,15 @@ The value equals `source` at the beginning of the transition and `destination` a
 
 Returns an animation value that follows a component boolean state.
 
+### `useSpringTransition(state: any, source: Node, destination: Node, velocity: AnimatedValue<number>, config: SpringConfig): Node`
+
+Returns a spring animation value that follows a component state.
+The value equals `source` at the beginning of the transition and `destination` at the end of the transition.
+
+### `useSpringToggle(toggle: boolean, velocity: AnimatedValue<number>, config: SpringConfig): Node`
+
+Returns a spring animation value that follows a component boolean state.
+
 ### `timing({ clock?: Clock, from?: Node, to?: Node, duration?: Node, easing?: EasingFunction }): Node`
 
 Convenience function to run a timing animation.

--- a/src/Animations.ts
+++ b/src/Animations.ts
@@ -4,7 +4,7 @@ import { useMemoOne } from "use-memo-one";
 
 import { TransformsStyle } from "react-native";
 import { min } from "./Math";
-import { timing } from "./AnimationRunners";
+import { timing, spring, SpringConfig } from "./AnimationRunners";
 
 const {
   Value,
@@ -117,3 +117,51 @@ export const useToggle = (
   easing: Animated.EasingFunction = Easing.linear
 ) =>
   useTransition(toggle, toggle ? 1 : 0, not(toggle ? 1 : 0), duration, easing);
+
+export const useSpringTransition = <T extends unknown>(
+  state: T,
+  src: Animated.Adaptable<number>,
+  dest: Animated.Adaptable<number>,
+  velocity: Animated.Value<number> | undefined = undefined,
+  config: SpringConfig | undefined = undefined
+) => {
+  const { transitionVal } = useMemoOne(
+    () => ({
+      transitionVal: new Value() as Animated.Value<number>
+    }),
+    []
+  );
+  useCode(
+    cond(
+      not(defined(transitionVal)),
+      set(transitionVal, src),
+      cond(
+        neq(transitionVal, src),
+        set(
+          transitionVal,
+          spring({
+            from: dest,
+            to: src,
+            velocity,
+            config
+          })
+        )
+      )
+    ),
+    [state]
+  );
+  return transitionVal;
+};
+
+export const useSpringToggle = (
+  toggle: boolean,
+  velocity: Animated.Value<number> | undefined = undefined,
+  config: SpringConfig | undefined = undefined
+) =>
+  useSpringTransition(
+    toggle,
+    toggle ? 1 : 0,
+    not(toggle ? 1 : 0),
+    velocity,
+    config
+  );


### PR DESCRIPTION
This commit adds new methods which are the same as `useTransition` and `useToggle`, but uses a spring animation rather than timing.

Currently, the code is literally just a copy and paste, however, if you are interested in adding this to the library then I can tidy it up to avoid the duplication with the two existing methods. I didn't want to do this upfront if you weren't interested in adding these methods.