### PR TITLE
Fix missing comma in example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -263,7 +263,7 @@ Example usage:
 ```js
 timing({
   duration: 10 * 1000,
-  from: 0
+  from: 0,
   to: 1,
   easing: Easing.linear,
 });


### PR DESCRIPTION
Just copied this and noticed a comma is missing in the README..

Spending this afternoon experimenting a bit, hopefully will be able to post a cool demo soon :) 

Cheers!