### PR TITLE
Fix interpolatePath unexpectedData error

### DIFF
--- a/src/SVG.ts
+++ b/src/SVG.ts
@@ -17,6 +17,7 @@ const {
   interpolate,
   multiply,
   lessThan,
+  concat,
   add
 } = Animated;
 
@@ -193,7 +194,7 @@ export const interpolatePath = (
       index === 0 ? string`M${mx},${my} ` : ""
     }C${p1x},${p1y} ${p2x},${p2y} ${p3x},${p3y}`;
   });
-  return string`${commands}`;
+  return concat(...commands);
 };
 
 export const bInterpolatePath = (


### PR DESCRIPTION
This address the issue with the unexpectedData red scree when attempting to use interpolatePath found here, https://github.com/wcandillon/react-native-redash/issues/154.

However, I have noticed, that when using this animating svg paths with this method combined with reanimated, they are not native, but javascript. I checked older versions of this, and checked previous Can It Be Done With React Native SVG animations like (https://github.com/wcandillon/can-it-be-done-in-react-native/tree/master/season3/src/LiquidSwipe) and notice these are also javascript animations (with many bridge crossings).

I am not sure if this is the intention or a restriction with animated svgs with reanimated, but this PR will re-align the interpolatePath function as it was previously, and allow animated SVG paths.