### PR TITLE
Fix: `onGestureEvent()` link in docs

### DIFF
--- a/packages/docs/src/gestures.mdx
+++ b/packages/docs/src/gestures.mdx
@@ -42,7 +42,7 @@ And for a horizontal one.
 
 ---
 
-### `onGestureEvent()`
+## `onGestureEvent()`
 
 ```tsx
 export declare const onGestureEvent: (nativeEvent: Partial<Adaptable<GestureHandlerStateChangeNativeEvent & TapGestureHandlerEventExtra>> | Partial<Adaptable<GestureHandlerStateChangeNativeEvent & LongPressGestureHandlerEventExtra>> | Partial<Adaptable<GestureHandlerStateChangeNativeEvent & ForceTouchGestureHandlerEventExtra>> | Partial<Adaptable<GestureHandlerStateChangeNativeEvent & PanGestureHandlerEventExtra>> | Partial<Adaptable<GestureHandlerStateChangeNativeEvent & PinchGestureHandlerEventExtra>> | Partial<Adaptable<GestureHandlerStateChangeNativeEvent & RotationGestureHandlerEventExtra>> | Partial<Adaptable<GestureHandlerStateChangeNativeEvent & FlingGestureHandlerEventExtra>>) => {


### PR DESCRIPTION
Quick fix to make `onGestureEvent()` searchable in the dos