### PR TITLE
Update Docs

### DIFF
--- a/packages/docs/src/animations.mdx
+++ b/packages/docs/src/animations.mdx
@@ -67,6 +67,8 @@ const snapPoint: (value: Animated.Adaptable<number>, velocity: Animated.Adaptabl
 
 Select a point based on a node value and its velocity.
 
+---
+
 ## `bInterpolate`
 
 ```tsx

--- a/packages/docs/src/animations.mdx
+++ b/packages/docs/src/animations.mdx
@@ -28,6 +28,26 @@ const [toggle state] = useMemoOne(() => [new Value(0), new Value(State.UNDETERMI
 
 ---
 
+## `useClocks()`
+
+```tsx
+const useClocks: (numberOfClocks: number, deps: Dependencies) => Animated.Clock[];
+```
+
+Create a number of clocks which lifecycle is granted by `deps`. For instance the code snippet below:
+
+```tsx
+const [clock1, clock2, clock3] = useClocks(3, []);
+```
+
+is a shortcut for
+
+```tsx
+const [clock1, clock2, clock3] = useMemoOne(() => [new Clock(), new Clock(), new Clock()], []);
+```
+
+---
+
 ## `useDiff()`
 
 ```tsx


### PR DESCRIPTION
- Adds missing `useClocks` function (addresses the latest comment on #158)
- 💄Add missing divider above `bInterpolate`
