### PR TITLE
Fix interpolateColor alpha interpolate value

### DIFF
--- a/src/Colors.ts
+++ b/src/Colors.ts
@@ -161,13 +161,12 @@ const interpolateColorsRGB = (
       extrapolate: Extrapolate.CLAMP
     })
   );
-  const a = round(
-    interpolate(animationValue, {
-      inputRange,
-      outputRange: colors.map(c => opacity(c)),
-      extrapolate: Extrapolate.CLAMP
-    })
-  );
+  const a = interpolate(animationValue, {
+    inputRange,
+    outputRange: colors.map(c => opacity(c)),
+    extrapolate: Extrapolate.CLAMP
+  });
+
   return color(r, g, b, a);
 };
 


### PR DESCRIPTION
Hi there 👋,

I notice that `interpolateColor` was having an issue with interpolating the alpha value, then i notice that the value been rounded 👇

```
  const a = round(
    interpolate(animationValue, {
      inputRange,
      outputRange: colors.map(c => opacity(c)),
      extrapolate: Extrapolate.CLAMP
    })
  );
```

so i just removed it and it fix the issue 😀