### PR TITLE
Fix docs for `onScrollEvent`

### DIFF
--- a/packages/docs/src/gestures.mdx
+++ b/packages/docs/src/gestures.mdx
@@ -47,7 +47,7 @@ Example usage for a vertical `ScrollView`.
 And for a horizontal one.
 
 ```tsx
-<Animated.ScrollView onScroll={onScroll({ x: new Value(0) })} horizontal />
+<Animated.ScrollView onScroll={onScrollEvent({ x: new Value(0) })} horizontal />
 ```
 
 ---


### PR DESCRIPTION
`onScroll` no longer exists so this has to be updated in the docs as well.