### PR TITLE
fix: mark side effect free

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -2,6 +2,7 @@
   "name": "react-native-redash",
   "version": "0.0.0-development",
   "description": "Utility library for React Native Reanimated",
+  "sideEffects": false,
   "main": "lib/module/index.js",
   "scripts": {
     "lint": "eslint --ext .ts,.tsx src",


### PR DESCRIPTION
As a first time contributor: thanks for your library! As far as I can see we can mark this library as side effect free to improve tree shaking: https://webpack.js.org/guides/tree-shaking/#mark-the-file-as-side-effect-free