### PR TITLE
Making sure withOffset works in tandem

### DIFF
--- a/packages/core/src/Gesture.ts
+++ b/packages/core/src/Gesture.ts
@@ -73,7 +73,11 @@ export const withOffset = (
 ) =>
   cond(
     eq(state, State.END),
-    [set(offset, add(offset, value)), offset],
+    [
+      set(offset, add(offset, value)),
+      set(state, State.UNDETERMINED),
+      offset,
+    ],
     add(offset, value)
   );
 


### PR DESCRIPTION
When rendering an animated component that uses two withOffset values, they will affect each other and keep incrementing if we don't reset the state to undetermined, because in PanGestureHandler it does not reset by itself.

```
return (
  <Animated.View
    style={{
      width: sub(value2, value1),
    }}
  />
);
```