### PR TITLE
Fix `transformOrigin` example

### DIFF
--- a/packages/docs/src/transformations.mdx
+++ b/packages/docs/src/transformations.mdx
@@ -41,7 +41,7 @@ Example:
 ```tsx
 <View
   style={{
-    transform: transformOrigin(cx, cy, { rotateX })
+    transform: transformOrigin({x: cx, y: cy}, { rotateX })
   }}
 />
 ```


### PR DESCRIPTION
Found a docs bug: The actual API has only two arguments and requires a `Point` as the first one.