### PR TITLE
Optimize useSpringTrasition and useTimingTransition

### DIFF
--- a/packages/core/src/Transitions.ts
+++ b/packages/core/src/Transitions.ts
@@ -56,9 +56,6 @@ export const withTransition = (
       timing(clock, state, config)
     ),
     cond(state.finished, stopClock(clock)),
-    Animated.call([], () => {
-      console.log('ev')
-    }),
     state.position,
   ]);
 };
@@ -99,9 +96,6 @@ export const withSpringTransition = (
       spring(clock, state, config)
     ),
     cond(state.finished, stopClock(clock)),
-    Animated.call([], () => {
-      console.log('ev')
-    }),
     state.position,
   ]);
 };

--- a/packages/core/src/Transitions.ts
+++ b/packages/core/src/Transitions.ts
@@ -85,7 +85,7 @@ export const withSpringTransition = (
     startClock(clock),
     cond(neq(config.toValue, value), [
       set(state.finished, 0),
-      startClock(clock)
+      startClock(clock),
     ]),
     set(config.toValue, value),
     cond(
@@ -106,7 +106,7 @@ export const useTransition = (
 ) => {
   const value: Animated.Value<number> = useMemo(() => new Value(0), []);
   useEffect(() => {
-    value.setValue(typeof state === "boolean" ? (state ? 1 : 0) : state)
+    value.setValue(typeof state === "boolean" ? (state ? 1 : 0) : state);
   }, [value, state]);
   // eslint-disable-next-line react-hooks/exhaustive-deps
   const transition = useMemo(() => withTransition(value, config), []);
@@ -120,7 +120,7 @@ export const useSpringTransition = (
   const value: Animated.Value<number> = useMemo(() => new Value(0), []);
 
   useEffect(() => {
-    value.setValue(typeof state === "boolean" ? (state ? 1 : 0) : state)
+    value.setValue(typeof state === "boolean" ? (state ? 1 : 0) : state);
   }, [value, state]);
 
   // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/packages/core/src/Transitions.ts
+++ b/packages/core/src/Transitions.ts
@@ -2,7 +2,6 @@ import { useMemo, useEffect } from "react";
 import Animated, { Easing } from "react-native-reanimated";
 import { State } from "react-native-gesture-handler";
 
-import { bin } from "./Math";
 import { SpringConfig, TimingConfig } from "./Animations";
 
 const {
@@ -17,7 +16,6 @@ const {
   stopClock,
   timing,
   neq,
-  useCode,
   SpringUtils,
 } = Animated;
 
@@ -109,7 +107,7 @@ export const useTransition = (
   const value: Animated.Value<number> = useMemo(() => new Value(0), []);
   useEffect(() => {
     value.setValue(typeof state === "boolean" ? (state ? 1 : 0) : state)
-  }, [state]);
+  }, [value, state]);
   // eslint-disable-next-line react-hooks/exhaustive-deps
   const transition = useMemo(() => withTransition(value, config), []);
   return transition;
@@ -123,7 +121,7 @@ export const useSpringTransition = (
 
   useEffect(() => {
     value.setValue(typeof state === "boolean" ? (state ? 1 : 0) : state)
-  }, [state]);
+  }, [value, state]);
 
   // eslint-disable-next-line react-hooks/exhaustive-deps
   const transition = useMemo(() => withSpringTransition(value, config), []);


### PR DESCRIPTION
I noticed that currently, the clock of spring and timing is never stopping thus the evaluation is happening all the time. It's nothing wrong when we have few components, but in my case, I'm extensively using those helpers across the app and noticed that native UI thread on Android is blocked by the number of operations. 

![image](https://user-images.githubusercontent.com/25709300/87190683-33325700-c2f3-11ea-839c-d1da38633814.png)

because more or less 50 evaluations are happening simultaneously.

I changed the way of evaluating to stop the clock when the animation is finished and start again of needed and noticed the boost of performance. 

![image](https://user-images.githubusercontent.com/25709300/87190870-a1771980-c2f3-11ea-9736-ba0b9aa69926.png)
(got rid of grey part responsible for reanimated methods)

I use already forked version with these changes in my app. 