### PR TITLE
fix(doc): update function rename in Vector doc

### DIFF
--- a/packages/docs/src/vectors.mdx
+++ b/packages/docs/src/vectors.mdx
@@ -19,7 +19,7 @@ export declare const vec: {
       x: Animated.Value<number>;
       y: Animated.Value<number>;
     },
-    invert: (a: Vector) => {
+    minus: (a: Vector) => {
         x: Animated.Node<number>;
         y: Animated.Node<number>;
     };


### PR DESCRIPTION
Hi, recently I'm watching PinchGesture video, and I find that `vec.invert` is no longer in the codebase but still in the document, and this is because this function was renamed, so I patch the doc and open this pull request.