### PR TITLE
v1 InterpolateColors Regression

### DIFF
--- a/src/v1/Colors.ts
+++ b/src/v1/Colors.ts
@@ -1,6 +1,6 @@
 import Animated from "react-native-reanimated";
 import { processColor } from "react-native";
-import interpolateNode from "react-native-reanimated/src/derived/interpolate";
+import interpolateNode, { Extrapolate } from "react-native-reanimated/src/derived/interpolate";
 
 import { mix } from "./Animations";
 import { clamp, fract } from "./Math";
@@ -118,14 +118,17 @@ const interpolateColorsHSV = (
   const h = interpolateNode(animationValue, {
     inputRange,
     outputRange: colorsAsHSV.map((c) => c.h),
+    extrapolate: Extrapolate.CLAMP
   });
   const s = interpolateNode(animationValue, {
     inputRange,
     outputRange: colorsAsHSV.map((c) => c.s),
+    extrapolate: Extrapolate.CLAMP
   });
   const v = interpolateNode(animationValue, {
     inputRange,
     outputRange: colorsAsHSV.map((c) => c.v),
+    extrapolate: Extrapolate.CLAMP
   });
   return hsv2color(h, s, v);
 };
@@ -139,23 +142,27 @@ const interpolateColorsRGB = (
     interpolateNode(animationValue, {
       inputRange,
       outputRange: colors.map((c) => red(c)),
+      extrapolate: Extrapolate.CLAMP
     })
   );
   const g = round(
     interpolateNode(animationValue, {
       inputRange,
       outputRange: colors.map((c) => green(c)),
+      extrapolate: Extrapolate.CLAMP
     })
   );
   const b = round(
     interpolateNode(animationValue, {
       inputRange,
       outputRange: colors.map((c) => blue(c)),
+      extrapolate: Extrapolate.CLAMP
     })
   );
   const a = interpolateNode(animationValue, {
     inputRange,
     outputRange: colors.map((c) => opacity(c)),
+    extrapolate: Extrapolate.CLAMP
   });
 
   return color(r, g, b, a);


### PR DESCRIPTION
Upgraded to v15 and all of our interpolateColor usages went berserk. Dig some digging and noticed [this change](https://github.com/wcandillon/react-native-redash/commit/3933f50465504bcf892cc74af09aa65a9ad119a0#diff-b5b730b0df3fd3b446d93242798ee74cR3). I think the removal of the extrapolation clamping is unintentional. 

