### PR TITLE
fix getYForX if path length is 0

### DIFF
--- a/src/Paths.ts
+++ b/src/Paths.ts
@@ -298,6 +298,9 @@ export const getYForX = (path: Path, x: number) => {
     }
     return false;
   });
+  if (p.length === 0) {
+    return 0;
+  }
   if (isCurve(p[0])) {
     return cubicBezierYForX(x, p[0].from, p[0].c1, p[0].c2, p[0].to);
   }


### PR DESCRIPTION
If this happens, it seems to crash / trigger redbox even if wrapped within try / catch for some reason.
It would be great to add this edge case handling (in my case it happened when I drag a graph to the very end).