### PR TITLE
update return type of interpolateColor function

### DIFF
--- a/src/v1/Colors.ts
+++ b/src/v1/Colors.ts
@@ -180,7 +180,7 @@ export const interpolateColor = (
   value: Animated.Adaptable<number>,
   config: ColorInterpolationConfig,
   colorSpace: "hsv" | "rgb" = "rgb"
-): Animated.Node<number> => {
+): Animated.Node<string> => {
   const { inputRange } = config;
   const outputRange = config.outputRange.map((c) =>
     typeof c === "number" ? c : (processColor(c) as number)


### PR DESCRIPTION
color should be string not number, because `backgroundColor` prop of `Animated.View` is defined as:
`backgroundColor?: string | typeof OpaqueColorValue | Animated.Node<string | typeof OpaqueColorValue | undefined> | undefined`