### PR TITLE
fix(bug): Fix types for react-native-gesture-handler@1.10.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   "peerDependencies": {
     "react": "*",
     "react-native": "*",
-    "react-native-gesture-handler": "*",
+    "react-native-gesture-handler": "1.10.x",
     "react-native-reanimated": ">=2.0.0-rc.0"
   },
   "devDependencies": {
@@ -41,7 +41,7 @@
     "jest": "^24.9.0",
     "react": "^16.8.6",
     "react-native": "^0.61.0",
-    "react-native-gesture-handler": "~1.5.0",
+    "react-native-gesture-handler": "~1.10.3",
     "react-native-reanimated": "2.1.0",
     "semantic-release": "^15.13.3",
     "semantic-release-cli": "^4.1.2",

--- a/src/v1/Gesture.ts
+++ b/src/v1/Gesture.ts
@@ -1,16 +1,16 @@
-import Animated, { diff, lessThan, or } from "react-native-reanimated";
-import {
-  FlingGestureHandlerEventExtra,
-  ForceTouchGestureHandlerEventExtra,
-  GestureHandlerStateChangeNativeEvent,
-  LongPressGestureHandlerEventExtra,
-  PanGestureHandlerEventExtra,
-  PinchGestureHandlerEventExtra,
-  RotationGestureHandlerEventExtra,
-  State,
-  TapGestureHandlerEventExtra,
-} from "react-native-gesture-handler";
 import { Platform } from "react-native";
+import {
+  FlingGestureHandlerEventPayload,
+  ForceTouchGestureHandlerEventPayload,
+  GestureHandlerStateChangeNativeEvent,
+  LongPressGestureHandlerEventPayload,
+  PanGestureHandlerEventPayload,
+  PinchGestureHandlerEventPayload,
+  RotationGestureHandlerEventPayload,
+  State,
+  TapGestureHandlerEventPayload,
+} from "react-native-gesture-handler";
+import Animated, { diff, lessThan, or } from "react-native-reanimated";
 
 import { snapPoint } from "./Animations";
 import { vec } from "./Vectors";
@@ -225,13 +225,13 @@ export const onScrollEvent = (contentOffset: {
 
 type NativeEvent = GestureHandlerStateChangeNativeEvent &
   (
-    | PanGestureHandlerEventExtra
-    | TapGestureHandlerEventExtra
-    | LongPressGestureHandlerEventExtra
-    | RotationGestureHandlerEventExtra
-    | FlingGestureHandlerEventExtra
-    | PinchGestureHandlerEventExtra
-    | ForceTouchGestureHandlerEventExtra
+    | PanGestureHandlerEventPayload
+    | TapGestureHandlerEventPayload
+    | LongPressGestureHandlerEventPayload
+    | RotationGestureHandlerEventPayload
+    | FlingGestureHandlerEventPayload
+    | PinchGestureHandlerEventPayload
+    | ForceTouchGestureHandlerEventPayload
   );
 
 type Adaptable<T> = { [P in keyof T]: Animated.Adaptable<T[P]> };

--- a/yarn.lock
+++ b/yarn.lock
@@ -5248,12 +5248,6 @@ growly@^1.3.0:
   resolved "https://registry.yarnpkg.com/growly/-/growly-1.3.0.tgz#f10748cbe76af964b7c96c93c6bcc28af120c081"
   integrity sha1-8QdIy+dq+WS3yWyTxrzCivEgwIE=
 
-"hammerjs@https://github.com/naver/hammer.js.git":
-  version "2.0.17-snapshot"
-  resolved "https://github.com/naver/hammer.js.git#54bc698b25edd6e1b76ca975ebaced5ce0467d51"
-  dependencies:
-    "@types/hammerjs" "^2.0.36"
-
 handlebars@^4.7.6:
   version "4.7.6"
   resolved "https://registry.yarnpkg.com/handlebars/-/handlebars-4.7.6.tgz#d4c05c1baf90e9945f77aa68a7a219aa4a7df74e"
@@ -5359,10 +5353,12 @@ hermes-engine@^0.2.1:
   resolved "https://registry.yarnpkg.com/hermes-engine/-/hermes-engine-0.2.1.tgz#25c0f1ff852512a92cb5c5cc47cf967e1e722ea2"
   integrity sha512-eNHUQHuadDMJARpaqvlCZoK/Nitpj6oywq3vQ3wCwEsww5morX34mW5PmKWQTO7aU0ck0hgulxR+EVDlXygGxQ==
 
-hoist-non-react-statics@^2.3.1:
-  version "2.5.5"
-  resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-2.5.5.tgz#c5903cf409c0dfd908f388e619d86b9c1174cb47"
-  integrity sha512-rqcy4pJo55FTTLWt+bU8ukscqHeE/e9KWvsOW2b/a3afxQZhwkQdT1rPPCJ0rYXdj4vNcasY8zHTH+jF/qStxw==
+hoist-non-react-statics@^3.3.0:
+  version "3.3.2"
+  resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz#ece0acaf71d62c2969c2ec59feff42a4b1a85b45"
+  integrity sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==
+  dependencies:
+    react-is "^16.7.0"
 
 home-or-tmp@^2.0.0:
   version "2.0.0"
@@ -9041,19 +9037,19 @@ react-devtools-core@^3.6.3:
     shell-quote "^1.6.1"
     ws "^3.3.1"
 
-react-is@^16.12.0, react-is@^16.8.1, react-is@^16.8.4:
+react-is@^16.12.0, react-is@^16.7.0, react-is@^16.8.1, react-is@^16.8.4:
   version "16.13.1"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
   integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==
 
-react-native-gesture-handler@~1.5.0:
-  version "1.5.6"
-  resolved "https://registry.yarnpkg.com/react-native-gesture-handler/-/react-native-gesture-handler-1.5.6.tgz#5d90145f624e3707db2930f43ab41579683e2375"
-  integrity sha512-z2jLUkRiRc0PBAC9UcXYkqy3VUzBG0cYQAGMsDHsd90JgrzudHAFRJV9fvFm18wNauFTNnJievjZ0C3rI2ydhw==
+react-native-gesture-handler@~1.10.3:
+  version "1.10.3"
+  resolved "https://registry.yarnpkg.com/react-native-gesture-handler/-/react-native-gesture-handler-1.10.3.tgz#942bbf2963bbf49fa79593600ee9d7b5dab3cfc0"
+  integrity sha512-cBGMi1IEsIVMgoox4RvMx7V2r6bNKw0uR1Mu1o7NbuHS6BRSVLq0dP34l2ecnPlC+jpWd3le6Yg1nrdCjby2Mw==
   dependencies:
     "@egjs/hammerjs" "^2.0.17"
-    hammerjs "https://github.com/naver/hammer.js.git"
-    hoist-non-react-statics "^2.3.1"
+    fbjs "^3.0.0"
+    hoist-non-react-statics "^3.3.0"
     invariant "^2.2.4"
     prop-types "^15.7.2"
 


### PR DESCRIPTION
I was upgrading to expo sdk-41 in a monorepo where we have a shared package and I got type errors in `src/v1/Gesture.ts` when using 

```
    "react-native-gesture-handler": "1.10.3",
    "react-native-reanimated": "2.1.0",
    "react-native-redash": "16.0.11", 
```
for that package.

It seems that its a simple rename in `react-native-gesture-handler`

I'm not sure what your process is for PR's but hope you find this useful.

Note: I used vscode's 'organize imports'