### PR TITLE
feat: added threshold to snapPoint

### DIFF
--- a/src/Physics.ts
+++ b/src/Physics.ts
@@ -9,23 +9,28 @@ export const snapPoint = (
   threshold = 0.5
 ): number => {
   "worklet";
-  const point = value + 0.2 * velocity;
+  const point = Math.abs(value + 0.2 * velocity);
+  const absolutePoints = points.map((_point) => Math.abs(_point));
 
   let startPointIndex = 0;
   let endPointIndex = points.length - 1;
 
   for (let i = 0, k = points.length - 1; i < points.length; i++, k--) {
-    if (points[i] < point) {
+    if (absolutePoints[i] < point) {
       startPointIndex = i;
     }
-    if (points[k] > point && points[k] < points[endPointIndex]) {
+    if (
+      absolutePoints[k] > point &&
+      absolutePoints[k] < absolutePoints[endPointIndex]
+    ) {
       endPointIndex = k;
     }
   }
 
   const middlePoint =
-    points[startPointIndex] +
-    (points[endPointIndex] - points[startPointIndex]) * threshold;
+    absolutePoints[startPointIndex] +
+    (absolutePoints[endPointIndex] - absolutePoints[startPointIndex]) *
+      threshold;
 
   return point < middlePoint ? points[startPointIndex] : points[endPointIndex];
 };

--- a/src/Physics.ts
+++ b/src/Physics.ts
@@ -5,11 +5,27 @@
 export const snapPoint = (
   value: number,
   velocity: number,
-  points: ReadonlyArray<number>
+  points: ReadonlyArray<number>,
+  threshold = 0.5
 ): number => {
   "worklet";
   const point = value + 0.2 * velocity;
-  const deltas = points.map((p) => Math.abs(point - p));
-  const minDelta = Math.min.apply(null, deltas);
-  return points.filter((p) => Math.abs(point - p) === minDelta)[0];
+
+  let startPointIndex = 0;
+  let endPointIndex = points.length - 1;
+
+  for (let i = 0, k = points.length - 1; i < points.length; i++, k--) {
+    if (points[i] < point) {
+      startPointIndex = i;
+    }
+    if (points[k] > point && points[k] < points[endPointIndex]) {
+      endPointIndex = k;
+    }
+  }
+
+  const middlePoint =
+    points[startPointIndex] +
+    (points[endPointIndex] - points[startPointIndex]) * threshold;
+
+  return point < middlePoint ? points[startPointIndex] : points[endPointIndex];
 };


### PR DESCRIPTION
## Overview

Hi @wcandillon 👋,

I have refactored the `snapPoint` to accept a `threshold` param and updated its handling ! this will help users to customise the `snapPoint` behaviour. https://github.com/gorhom/react-native-bottom-sheet/issues/563

this was enabled by using to pointers to find the points surround the provided `value` then get the middle point and multiple it by the `threshold` to evaluate which point will be returned.

`threshold` default value is `0.5`.

### Testing

```ts
const points = [100, 200];

console.log('snapPoint', snapPoint(150, 0, points));
// middlePoint 150, snapPoint 200

console.log('snapPoint', snapPoint(150, 0, points, 0.75));
// middlePoint 175, snapPoint 100

console.log('snapPoint', snapPoint(125, 0, points, 0.25));
// middlePoint 125, snapPoint 200
```
