### PR TITLE
Use Extrapolation enum instead of Animated.Extrapolate to support reanimated v3

### DIFF
--- a/src/Paths.ts
+++ b/src/Paths.ts
@@ -1,4 +1,4 @@
-import Animated, { interpolate } from "react-native-reanimated";
+import { interpolate, Extrapolation } from "react-native-reanimated";
 import parseSVG from "parse-svg-path";
 import absSVG from "abs-svg-path";
 import normalizeSVG from "normalize-svg-path";
@@ -77,7 +77,7 @@ export const interpolatePath = (
   value: number,
   inputRange: number[],
   outputRange: Path[],
-  extrapolate = Animated.Extrapolate.CLAMP
+  extrapolate = Extrapolation.CLAMP
 ) => {
   "worklet";
   const path = {
@@ -152,7 +152,7 @@ export const mixPath = (
   value: number,
   p1: Path,
   p2: Path,
-  extrapolate = Animated.Extrapolate.CLAMP
+  extrapolate = Extrapolation.CLAMP
 ) => {
   "worklet";
   return interpolatePath(value, [0, 1], [p1, p2], extrapolate);


### PR DESCRIPTION
Reanimated v3 removes the v1 implementation. The Animated.Extrapolate enum is part of what was removed. Instead there is the `Extrapolation` enum we can use. The only potential issue is it was only introduced in reanimated@2.3.0 (https://github.com/software-mansion/react-native-reanimated/commit/cb651ecf9b6d4df715ab7da4686f66140e5f13a3). Another potential solution to support both would be to use string literals instead of the enum.