### PR TITLE
added dependency List to ReText 4 RNweb animations

### DIFF
--- a/src/ReText.tsx
+++ b/src/ReText.tsx
@@ -25,7 +25,7 @@ const ReText = (props: TextProps) => {
       // Here we use any because the text prop is not available in the type
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
     } as any;
-  });
+  }, [text]);
   return (
     <AnimatedTextInput
       underlineColorAndroid="transparent"


### PR DESCRIPTION
So, 
While Using ReText with RNweb, It's required to pass a dependency List to useAnimatedProps and some other hooks 
as in the dox [Web without the Babel plugin](https://docs.swmansion.com/react-native-reanimated/docs/guides/web-support#web-without-the-babel-plugin)

A simple change to `/src/ReText.tsx`
```
  const animatedProps = useAnimatedProps(() => {
      return {
        text: text.value,
  ...
      } as any;
 }, [text]);  // <-- added this to the  dependency List [text] that's it
```

hope it gets merged soon,
currently using it vie yarn patch packages  
    