### PR TITLE
fix(💄): Prevent reading from sharedValue during component render

### DIFF
--- a/src/ReText.tsx
+++ b/src/ReText.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useMemo } from "react";
 import type { TextInputProps, TextProps as RNTextProps } from "react-native";
 import { StyleSheet, TextInput } from "react-native";
 import Animated, { useAnimatedProps } from "react-native-reanimated";
@@ -19,6 +19,7 @@ const AnimatedTextInput = Animated.createAnimatedComponent(TextInput);
 
 const ReText = (props: TextProps) => {
   const { style, text, ...rest } = props;
+  const initialValue = useMemo(() => text.value, [text]);
   const animatedProps = useAnimatedProps(() => {
     return {
       text: text.value,
@@ -30,7 +31,7 @@ const ReText = (props: TextProps) => {
     <AnimatedTextInput
       underlineColorAndroid="transparent"
       editable={false}
-      value={text.value}
+      value={initialValue}
       style={[styles.baseStyle, style || undefined]}
       {...rest}
       {...{ animatedProps }}


### PR DESCRIPTION
Reanimated in strict mode (default) gives a warning when the parent component using ReText is re-rendered:
> WARN  [Reanimated] Reading from `value` during component render. Please ensure that you do not access the `value` property or use `get` method of a shared value while React is rendering a component.

This is because it's reading `text.value` directly in the component body (for the initial value). `useMemo` can be used to explicitly get the first value as a React value.